### PR TITLE
Change default end_time of election to a time that is in the future

### DIFF
--- a/dapp/index.html
+++ b/dapp/index.html
@@ -33,6 +33,33 @@
             });
         }
 
+        function setupElection() {
+            const description = document.getElementById('setupElectionDescription').value;
+            // Convert to an ISO string, which includes the timezone.
+            const end_time = new Date(Date.parse(document.getElementById('setupElectionEndtime').value)).toISOString();
+            // Split into a list of strings and trim each element.
+            const options = document.getElementById('setupElectionOptions').value.split(',').map((s) => s.trim());
+
+            client.sendTransaction(
+                currentAccountAddress,
+                concordiumSDK.AccountTransactionType.InitContract,
+                {
+                    amount: new concordiumSDK.CcdAmount(0n),
+                    moduleRef: moduleReference,
+                    initName: "voting",
+                    maxContractExecutionEnergy: 3000n,
+                },
+                {
+                    description: description,
+                    options: options,
+                    end_time: end_time
+                },
+                rawModuleSchema,
+            )
+                .then((msg) => alert(`Successfully set up new contest with transaction hash: "${msg}"`))
+                .catch(alert);
+        }
+
         function vote() {
             const contractIndex = document.getElementById('votingContractIndex').value;
             const votingOption = document.getElementById('votingOption').value;
@@ -82,33 +109,6 @@
             } else {
                 alert("You need to connect first.");
             }
-        }
-
-        function setupElection() {
-            const description = document.getElementById('setupElectionDescription').value;
-            // Convert to an ISO string, which includes the timezone.
-            const end_time = new Date(Date.parse(document.getElementById('setupElectionEndtime').value)).toISOString();
-            // Split into a list of strings and trim each element.
-            const options = document.getElementById('setupElectionOptions').value.split(',').map((s) => s.trim());
-
-            client.sendTransaction(
-                currentAccountAddress,
-                concordiumSDK.AccountTransactionType.InitContract,
-                {
-                    amount: new concordiumSDK.CcdAmount(0n),
-                    moduleRef: moduleReference,
-                    initName: "voting",
-                    maxContractExecutionEnergy: 3000n,
-                },
-                {
-                    description: description,
-                    options: options,
-                    end_time: end_time
-                },
-                rawModuleSchema,
-            )
-                .then((msg) => alert(`Successfully set up new contest with transaction hash: "${msg}"`))
-                .catch(alert);
         }
 
         function viewResult() {

--- a/dapp/index.html
+++ b/dapp/index.html
@@ -1,134 +1,123 @@
 <!doctype html>
 <html lang="en">
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <title>Asiavision</title>
-        <meta name="description" content="">
-        <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <!-- We use Sakura, a classless CSS framework to make the site look decent -->
-        <link rel="stylesheet" href="https://unpkg.com/sakura.css/css/sakura.css" type="text/css">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title>Eurovision</title>
+    <meta name="description" content="">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
 
-        <script src="/sdk.js"></script>
-        <script src="/helpers.js"></script>
+    <!-- We use Sakura, a classless CSS framework to make the site look decent -->
+    <link rel="stylesheet" href="https://unpkg.com/sakura.css/css/sakura.css" type="text/css">
 
-        <script>
-            let currentAccountAddress = null;
-            let client = null;
+    <script src="/sdk.js"></script>
+    <script src="/helpers.js"></script>
 
-            let contractIndex = 2295;
+    <script>
+        let currentAccountAddress = null;
+        let client = null;
 
-            // Get the schema with the following command:
-            // cargo concordium build --schema-base64-out -
-            let rawModuleSchema = '//8DAQAAAAYAAAB2b3RpbmcBABQAAwAAAAsAAABkZXNjcmlwdGlvbhYCBwAAAG9wdGlvbnMQAhYCCAAAAGVuZF90aW1lDQIAAAAEAAAAdmlldwEUAAMAAAALAAAAZGVzY3JpcHRpb24WAggAAABlbmRfdGltZQ0FAAAAdGFsbHkSAhYCBAQAAAB2b3RlBBYCFQQAAAANAAAAUGFyc2luZ0ZhaWxlZAIOAAAAVm90aW5nRmluaXNoZWQCEwAAAEludmFsaWRWb3RpbmdPcHRpb24CDQAAAENvbnRyYWN0Vm90ZXICAA';
-            // Get the module reference with the following command:
-            // concordium-client module deploy ./voting_contract.wasm.v1 --sender <AccountAddress>
-            const moduleReference = new concordiumSDK.ModuleReference('0f3f4bc70386aed412d3d3e2fc01ad390524e343872db7cfcccc5cd935532124');
+        // Get the schema in base64 format with the following command:
+        // cargo concordium build --schema-base64-out -
+        let rawModuleSchema = '//8DAQAAAAYAAAB2b3RpbmcBABQAAwAAAAsAAABkZXNjcmlwdGlvbhYCBwAAAG9wdGlvbnMQAhYCCAAAAGVuZF90aW1lDQIAAAAEAAAAdmlldwEUAAMAAAALAAAAZGVzY3JpcHRpb24WAggAAABlbmRfdGltZQ0FAAAAdGFsbHkSAhYCBAQAAAB2b3RlBBYCFQQAAAANAAAAUGFyc2luZ0ZhaWxlZAIOAAAAVm90aW5nRmluaXNoZWQCEwAAAEludmFsaWRWb3RpbmdPcHRpb24CDQAAAENvbnRyYWN0Vm90ZXICAA==';
 
-            function connect() {
-                client.connect().then((accountAddress) => {
-                        currentAccountAddress = accountAddress;
-                        document.getElementById('accountAddress').innerHTML = currentAccountAddress;
-                  });
-            }
+        // Get the module reference with the following command:
+        // concordium-client module deploy ./voting_contract.wasm.v1 --sender <AccountAddress> --grpc-port 10000 --grpc-ip node.testnet.concordium.com
+        const moduleReference = new concordiumSDK.ModuleReference('0f3f4bc70386aed412d3d3e2fc01ad390524e343872db7cfcccc5cd935532124');
 
-            function vote(contractIndex, votingOption) {
-                client
-                    .sendTransaction(
-                        currentAccountAddress,
-                        concordiumSDK.AccountTransactionType.Update,
-                        {
-                            amount: new concordiumSDK.CcdAmount(0n),
-                            contractAddress: {
-                                index: contractIndex,
-                                subindex: 0n,
-                            },
-                            receiveName: 'voting.vote',
-                            maxContractExecutionEnergy: 3000n,
-                        },
-                        votingOption,
-                        rawModuleSchema,
-                    )
-                    .then((msg) => alert(`Successfully sent vote with transaction hash: "${msg}"`))
-                    .catch(alert);
-            }
+        function connect() {
+            client.connect().then((accountAddress) => {
+                currentAccountAddress = accountAddress;
+                document.getElementById('accountAddress').innerHTML = currentAccountAddress;
+            });
+        }
 
-            function idCheckedVote() {
-                const contractIndex = document.getElementById('votingContractIndex').value;
-                const country = document.getElementById('votingOption').value;
+        function vote() {
+            const contractIndex = document.getElementById('votingContractIndex').value;
+            const votingOption = document.getElementById('votingOption').value;
 
-                const statement = new concordiumSDK.IdStatementBuilder()
-                                        .addNonMembership(concordiumSDK.AttributesKeys.countryOfResidence, [country])
-                                        .getStatement();
-                // A challenge is some random value included in the proof so they cannot be reused.
-                // In a real setup we would verify that the proof is valid and includes the challenge.
-                // And we would check that the included challenge is not older than x minutes.
-                const challenge = 'AAAAAAAA';
-                if (currentAccountAddress != null) {
-                    client
-                        .requestIdProof(currentAccountAddress, statement, challenge)
-                        .then((proof) => {
-                            console.log("Got valid ID proof:", proof);
-                            vote(contractIndex, country);
-                        })
-                        .catch((error) => {
-                            console.log("Could not create ID proof:", error);
-                            alert("You cannot vote on your own country! We busted a cheater!");
-                        });
-                } else {
-                    alert("You need to connect first.");
-                }
-            }
-
-            function uploadSchema() {
-                const readFileToBuffer = async (file) => {
-                    let arrayBuffer = await file.arrayBuffer();
-                    return arrayBuffer;
-                };
-
-                let file = document.getElementById('schemaFile').files[0];
-                readFileToBuffer(file).then((schemaBuffer) => {
-                    let base64Schema = btoa(String.fromCharCode(...new Uint8Array(schemaBuffer))).trim();
-                    rawModuleSchema = base64Schema;
-                    document.getElementById('schemaContents').innerHTML = rawModuleSchema;
-                });
-            }
-
-            function setupElection() {
-                const description = document.getElementById('setupElectionDescription').value;
-                // Convert to an ISO string, which includes the timezone.
-                const end_time = new Date(Date.parse(document.getElementById('setupElectionEndtime').value)).toISOString();
-                // Split into a list of strings and trim each element.
-                const options = document.getElementById('setupElectionOptions').value.split(',').map((s) => s.trim());
-
-                client.sendTransaction(
+            client
+                .sendTransaction(
                     currentAccountAddress,
-                    concordiumSDK.AccountTransactionType.InitContract,
+                    concordiumSDK.AccountTransactionType.Update,
                     {
                         amount: new concordiumSDK.CcdAmount(0n),
-                        moduleRef: moduleReference,
-                        initName: "voting",
+                        contractAddress: {
+                            index: contractIndex,
+                            subindex: 0n,
+                        },
+                        receiveName: 'voting.vote',
                         maxContractExecutionEnergy: 3000n,
                     },
-                    {
+                    votingOption,
+                    rawModuleSchema,
+                )
+                .then((msg) => alert(`Successfully sent vote with transaction hash: "${msg}"`))
+                .catch(alert);
+        }
+
+        function idCheckedVote() {
+            const contractIndex = document.getElementById('votingContractIndex').value;
+            const votingOption = document.getElementById('votingOption').value;
+
+            const statement = new concordiumSDK.IdStatementBuilder()
+                .addNonMembership(concordiumSDK.AttributesKeys.countryOfResidence, [votingOption])
+                .getStatement();
+            // A challenge is some random value included in the proof so they cannot be reused.
+            // In a real setup we would verify that the proof is valid and includes the challenge.
+            // And we would check that the included challenge is not older than x minutes.
+            const challenge = 'AAAAAAAA';
+            if (currentAccountAddress != null) {
+                client
+                    .requestIdProof(currentAccountAddress, statement, challenge)
+                    .then((proof) => {
+                        console.log("Got valid ID proof:", proof);
+                        vote();
+                    })
+                    .catch((error) => {
+                        console.log("Could not create ID proof:", error);
+                        alert("You cannot vote on your own country! We busted a cheater!");
+                    });
+            } else {
+                alert("You need to connect first.");
+            }
+        }
+
+        function setupElection() {
+            const description = document.getElementById('setupElectionDescription').value;
+            // Convert to an ISO string, which includes the timezone.
+            const end_time = new Date(Date.parse(document.getElementById('setupElectionEndtime').value)).toISOString();
+            // Split into a list of strings and trim each element.
+            const options = document.getElementById('setupElectionOptions').value.split(',').map((s) => s.trim());
+
+            client.sendTransaction(
+                currentAccountAddress,
+                concordiumSDK.AccountTransactionType.InitContract,
+                {
+                    amount: new concordiumSDK.CcdAmount(0n),
+                    moduleRef: moduleReference,
+                    initName: "voting",
+                    maxContractExecutionEnergy: 3000n,
+                },
+                {
                     description: description,
                     options: options,
                     end_time: end_time
-                    },
-                    rawModuleSchema,
-                    )
+                },
+                rawModuleSchema,
+            )
                 .then((msg) => alert(`Successfully set up new contest with transaction hash: "${msg}"`))
                 .catch(alert);
-            }
+        }
 
-            function viewResult() {
-                const contractIndex = document.getElementById('resultContractIndex').value;
+        function viewResult() {
+            const contractIndex = document.getElementById('resultContractIndex').value;
 
-                client.getJsonRpcClient().invokeContract({
-                    contract: { index: BigInt(contractIndex), subindex: BigInt(0) },
-                    method: 'voting.view',
-                })
+            client.getJsonRpcClient().invokeContract({
+                contract: { index: BigInt(contractIndex), subindex: BigInt(0) },
+                method: 'voting.view',
+            })
                 .then((viewResult) => {
                     let returnValue = concordiumSDK.deserializeReceiveReturnValue(
                         concordiumSDK.toBuffer(viewResult.returnValue, 'hex'),
@@ -144,67 +133,60 @@
                     document.getElementById('resultTally').innerHTML = tally;
                 })
                 .catch(alert);
-            }
+        }
 
-            function setupPage() {
-                // Get the client.
-                concordiumHelpers.detectConcordiumProvider()
-                                 .then((c) => client = c)
-                                 .catch(alert);
+        function setupPage() {
+            // Get the client.
+            concordiumHelpers.detectConcordiumProvider()
+                .then((c) => client = c)
+                .catch(alert);
+        }
 
-                // Set default values.
-                document.getElementById('votingContractIndex').value = contractIndex;
-                document.getElementById('resultContractIndex').value = contractIndex;
-                document.getElementById('schemaContents').innerHTML = rawModuleSchema;
-            }
+        // Set up the page when the DOM is loaded.
+        addEventListener("DOMContentLoaded", (_) => setupPage());
+    </script>
 
-            // Set up the page when the DOM is loaded.
-            addEventListener("DOMContentLoaded", (_) => setupPage());
-        </script>
+</head>
 
-    </head>
-    <body>
-        <article>
-        <h1>AsiaVision</h1>
+<body>
+    <article>
+        <h1>EuroVision</h1>
 
-            <section>
-                <p><b>Connected to account: </b><br /><em id="accountAddress">None</em></p>
-                <button onclick="connect()">Connect</button>
-            </section>
+        <section>
+            <p><b>Connected to account: </b><br /><em id="accountAddress">None</em></p>
+            <button onclick="connect()">Connect</button>
+        </section>
 
-            <section>
-                <h2>Upload schema</h2>
-                <input type="file", id="schemaFile" /><br />
-                <button onclick="uploadSchema()">Upload schema</button><br />
-                <label>Schema:<pre><code id="schemaContents"></code></pre></label>
-            </section>
+        <section>
+            <h2>Set up a new song contest</h2>
+            <p>Enter countries in a comma-separated list:</p>
+            <label>Description:<br /><input type="text" placeholder="Song contest for..." value="Eurovision"
+                    id="setupElectionDescription" /></label>
+            <label>Endtime:<br /><input type="datetime-local" value="2030-01-08T20:00"
+                    id="setupElectionEndtime" /></label>
+            <label>Country codes (comma-separated):<textarea placeholder="IN, DK, DE"
+                    id="setupElectionOptions">IN, DK, DE</textarea></label>
+            <button onclick="setupElection()">Create new contest</button>
+        </section>
 
-            <section>
-                <h2>Set up a new song contest</h2>
-                <p>Enter countries in a comma-separated list:</p>
-                <label>Description:<br /><input type="text" placeholder="Song contest for..." value="Asiavision" id="setupElectionDescription" /></label>
-                <label>Endtime:<br /><input type="datetime-local" value="2023-01-08T20:00" id="setupElectionEndtime" /></label>
-                <label>Country codes (comma-separated):<textarea placeholder="IN, DK, DE" id="setupElectionOptions">IN, DK, DE</textarea></label>
-                <button onclick="setupElection()">Create new contest</button>
-            </section>
+        <section>
+            <h2>Voting!</h2>
+            <label>Contract index:<br /><input type="number" min="0" value="2732" id="votingContractIndex" /></label>
+            <label>Vote for:<br /><input type="text" id="votingOption" /></label>
+            <button onclick="idCheckedVote()">Vote!</button>
+        </section>
 
-            <section>
-                <h2>Voting!</h2>
-                <label>Contract index:<br /><input type="number" min="0" id="votingContractIndex" /></label>
-                <label>Vote for:<br /><input type="text" id="votingOption" /></label>
-                <button onclick="idCheckedVote()">Vote!</button>
-            </section>
+        <section>
+            <h2>Results</h2>
+            <label>Contract index:<br /><input type="number" min="0" value="2732" id="resultContractIndex" /></label>
+            <button onclick="viewResult()">Get results</button>
+            <br />
+            <label>Description:<br /><input disabled id="resultDescription" /></label>
+            <label>Endtime:<br /><input disabled id="resultEndtime" /></label>
+            <label>Tally:<br /><textarea disabled id="resultTally"></textarea></label>
+        </section>
 
-            <section>
-                <h2>Results</h2>
-                <label>Contract index:<br /><input type="number" min="0" id="resultContractIndex" /></label>
-                <button onclick="viewResult()">Get results</button>
-                <br />
-                <label>Description:<br /><input disabled id="resultDescription" /></label>
-                <label>Endtime:<br /><input disabled id="resultEndtime" /></label>
-                <label>Tally:<br /><textarea disabled id="resultTally"></textarea></label>
-            </section>
+    </article>
+</body>
 
-        </article>
-    </body>
 </html>


### PR DESCRIPTION
## Purpose

- Initializing a smart contract uses a default `end_time` that is now in the future. Previously, if the user did not update the `end_time`, the `vote` transaction in the next step would have reverted with an error message. Making it easier for people to try out this front-end by using an `end_time` that is in the future by default.

- Some small adjustments to the code that I used during the presentation (e.g. the `vote()` function or the `idCheckedVote()` function could be used and be connected to the `vote` button without having to rename variables).

- Removed the `upload schema` section because base64 can be now converted and output by `cargo concordium`.

- There is much less code change than github displays. Most of it is just a different indent because of my formatter.